### PR TITLE
Feature/fix phpunit configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.phpunit.result.cache

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpunit colors="true">
+    <testsuites>
+        <testsuite name="Application unit tests">
+            <directory suffix="Unit.php">./tests/Units</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/MDBToolsTestCase.php
+++ b/tests/MDBToolsTestCase.php
@@ -21,7 +21,7 @@ class MDBToolsTestCase extends TestCase
     /**
      * @var string
      */
-    protected $sampleFile = 'sample.mdb';
+    protected $sampleFile = __DIR__ . '/../sample.mdb';
 
     /**
      * create env version of test case class

--- a/tests/MDBToolsTestCase.php
+++ b/tests/MDBToolsTestCase.php
@@ -6,7 +6,7 @@ use MDBTools\Parsers\IParser;
 use MDBTools\Tables\ITable;
 use PHPUnit\Framework\TestCase;
 
-class MDBToolsTestCase extends TestCase
+abstract class MDBToolsTestCase extends TestCase
 {
     /**
      * @var IParser


### PR DESCRIPTION
I added a config file for phpUnit so the test can be run more easily (e.g. from the command line by calling vendor/bin/phpunit or from an IDE). I also fixed the path to the test file and marked the MDBToolsTestCase as abstract.