### PR TITLE
Fixed the test to see if mdb-tables is installed.

### DIFF
--- a/src/Parsers/MDBParser.php
+++ b/src/Parsers/MDBParser.php
@@ -146,7 +146,7 @@ class MDBParser implements IParser
      */
     private function MDBToolsInstalled(): bool
     {
-        return strpos(shell_exec('mdb-tables'), 'command not found') === false;
+        return strpos(shell_exec('mdb-tables --version'), 'command not found') === false;
     }
 
     /**


### PR DESCRIPTION
If no argument is passed, it will output an error to stderr and the method will return false. Passing --version fixes this.